### PR TITLE
Press Assets

### DIFF
--- a/press-assets/index.md
+++ b/press-assets/index.md
@@ -3,5 +3,10 @@ layout: page
 title: Press Assets
 permalink: /press-assets/
 ---
+**Logo Assets**
 
-This page intentionally left blank for now...
+The logos on this page may be used, as provided with no changes, by Badge Alliance members and Issuers of Open Badges, as well as press agencies and journalists publishing articles about Open Badges. 
+
+Declare your support for Open Badges with Issuer insignia for your website. Show the world your badges align with the Open Badges and that they should expect the full range of Open Badges features when they see badges referenced on your site. 
+
+Insert logo assets 


### PR DESCRIPTION
**Logo Assets** 

The logos on this page may be used, as provided with no changes, by Badge Alliance members and Issuers of Open Badges, as well as press agencies and journalists publishing articles about Open Badges. 

Declare your support for Open Badges with Issuer insignia for your website. Show the world your badges align with the Open Badges and that they should expect the full range of Open Badges features when they see badges referenced on your site.
