### PR TITLE
Directory Working Group needs added

### DIFF
--- a/badge-alliance/working-groups/index.md
+++ b/badge-alliance/working-groups/index.md
@@ -4,4 +4,26 @@ title: Badge Alliance
 permalink: /badge-alliance/working-groups/
 ---
 
-This page intentionally left blank for now...
+Directory Working Group
+
+In 2014, this group created a worldwide directory of Open Badges, making it possible for learners and organizations to find various badge Issuers, their badges, and programs. With the directory work as a foundation, the members also explored how search and discovery of Open Badges could be supported. 
+
+Directory Resources:
+
+The [Directory mailing list](https://groups.google.com/forum/#!forum/ba-directory) has been archived. Please join us at the [Open Badges community space](https://groups.google.com/forum/#!forum/openbadges).
+
+The Directory Working Group understood that an Open Badges Directory, in its full potential, could be the foundational search engine for Open Badges upon which additional, exciting applications and services like a pathway generator, learning recommendation engine, and personalized learning could be developed. 
+
+1st Cycle Goals
+
+For the first cycle, the Directory Working Group set out to create a basic prototype that would make it possible for learners and organizations to find and connect to various badge Issuers, their badges, and their programs. This entailed the following process:
++ Define the scope of the initial badge directory
++ Enlist badge Issuers to register badge classes
++ Clear documentation explaining API end points and how to use the directory
+
+And the following deliverables:
++ Working beta directory (using Node API Library):
+ + [Prototype](http://directory.openbadges.org/examples/browser/#/recent)
++ Tutorials and documentation
+ + http://badgealliance.github.io/openbadges-directory/
+


### PR DESCRIPTION
Hi Nate.

The Directory Working Group needs to be added to the Archived Working Groups section.

http://openbadges.github.io/openbadges.org-static/badge-alliance/working-groups/
